### PR TITLE
getting rid of Fraction by building priceMul and priceDiv with bignumber.js

### DIFF
--- a/src/exchange/exchange.ts
+++ b/src/exchange/exchange.ts
@@ -103,9 +103,8 @@ export class Web3Interface {
     let exchange = new Contract(orderContract, this.exchangeAbi as any, this.wallet)
     let decimals = await token.decimals()
 
-    let parsedPrice = new Fraction(price)
-      .div(new Fraction(10).pow(Number(decimals.toString())))
-      .mul(new Fraction(10).pow(etherDecimals))
+    let priceMul = new BigNumberJS(price).shiftedBy(etherDecimals)
+    let priceDiv = new BigNumberJS(1).shiftedBy(-decimals)
 
     let parsedAmount = amount.times(price).shiftedBy(etherDecimals).toFixed()
 
@@ -113,8 +112,8 @@ export class Web3Interface {
 
     let tx = await exchange.sellEther(
       tokenAddress,
-      toSuitableBigNumber(parsedPrice.n),
-      toSuitableBigNumber(parsedPrice.d),
+      toSuitableBigNumber(priceMul.toFixed()),
+      toSuitableBigNumber(priceDiv.toFixed()),
       { gasPrice: gasPrice, value: toSuitableBigNumber(parsedAmount), gasLimit: gaslimit }
     )
     return tx.hash

--- a/src/exchange/exchange.ts
+++ b/src/exchange/exchange.ts
@@ -104,7 +104,7 @@ export class Web3Interface {
     let decimals = await token.decimals()
 
     let priceMul = new BigNumberJS(price).shiftedBy(etherDecimals)
-    let priceDiv = new BigNumberJS(1).shiftedBy(-decimals)
+    let priceDiv = new BigNumberJS(1).shiftedBy(decimals)
 
     let parsedAmount = amount.times(price).shiftedBy(etherDecimals).toFixed()
 


### PR DESCRIPTION
Got rid of Fraction in let parsedPrice. In future smart contracts we should not need priceMul and priceDiv. But since they are there now, we can at least do it with bignumber.js and eliminate precision worries.

This also fixes amount * price (previous pull request). 

This kicks Fraction completely out of newBuyOrder!

This change is intended to work the same as the original from the calling user's standpoint.

Not tested. Just ideas.